### PR TITLE
Improve note reading error handling

### DIFF
--- a/plugins/note_taker/notetaker_handle.py
+++ b/plugins/note_taker/notetaker_handle.py
@@ -43,9 +43,21 @@ def create_note(note_name: str) -> bool:
 def delete_note(note_name: str) -> None:
     os.remove(get_note_path(note_name))
 
-def read_note(note_name: str) -> str:
-    with open(get_note_path(note_name), "r", encoding="utf-8") as f:
-        return f.read()
+def read_note(note_name: str) -> dict:
+    """读取指定笔记内容并返回统一的结果结构"""
+    if not note_name or os.path.basename(note_name) != note_name:
+        return {"status": "error", "message": "无效的笔记标题"}
+
+    note_path = get_note_path(note_name)
+    if not os.path.exists(note_path):
+        return {"status": "error", "message": f"笔记 '{note_name}' 不存在"}
+
+    try:
+        with open(note_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        return {"status": "success", "content": content}
+    except Exception as e:
+        return {"status": "error", "message": str(e)}
 
 
 def search_notes(keyword: str) -> list[str]:

--- a/plugins/note_taker/notetaker_ui.py
+++ b/plugins/note_taker/notetaker_ui.py
@@ -70,11 +70,11 @@ def open_notes_window(notes: list[str], master_window=None):
         selection = listbox.curselection()
         if selection:
             note_name = listbox.get(selection[0])
-            try:
-                content = read_note(note_name)
-                open_note_editor(note_name, content, master_window)
-            except Exception as e:
-                messagebox.showerror("打开失败", f"无法打开笔记 '{note_name}': {e}")
+            result = read_note(note_name)
+            if result.get("status") == "success":
+                open_note_editor(note_name, result.get("content", ""), master_window)
+            else:
+                messagebox.showerror("打开失败", f"无法打开笔记 '{note_name}': {result.get('message', '')}")
 
     listbox.bind("<Double-1>", on_open)
 


### PR DESCRIPTION
## Summary
- handle invalid note name and not found cases in `read_note`
- adapt plugin logic to work with the new `read_note` result structure
- update UI double-click note opening

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f2d6c5a14832c83560080370f459c