### PR TITLE
Add read_note mapping

### DIFF
--- a/plugins/note_taker/intent_map.json
+++ b/plugins/note_taker/intent_map.json
@@ -7,5 +7,6 @@
   "search": "search_notes",
   "search_notes": "search_notes",
   "search_notes_by_keyword": "search_notes",
-  "clarify_action": "read_note"
+  "clarify_action": "read_note",
+  "read_note": "read_note"
 }


### PR DESCRIPTION
## Summary
- update `intent_map.json` for `note_taker` plugin with `read_note` mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f2d69e770832c8a307a5ce208197d