### PR TITLE
Add edit_note command

### DIFF
--- a/plugins/note_taker/__init__.py
+++ b/plugins/note_taker/__init__.py
@@ -31,6 +31,7 @@ class NoteTakerPlugin(BasePlugin):
         return [
             "create_note",
             "read_note",
+            "edit_note",
             "delete_note",
             "list_notes",
             "search_notes",
@@ -63,10 +64,24 @@ class NoteTakerPlugin(BasePlugin):
             result = read_note(title)
             if result.get("status") == "success":
                 content = result.get("content", "")
-                run_on_ui(controller, open_note_editor, title, content, controller.view.master)
+                if content:
+                    msg = f"笔记 '{title}' 的内容如下:\n{content}"
+                else:
+                    msg = f"笔记 '{title}' 目前是空的。"
+                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", msg, "nana_sender")))
             else:
                 err = result.get("message", "")
                 controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana酱", err, "error_sender")))
+        elif command == "edit_note":
+            if not title:
+                return
+            result = read_note(title)
+            if result.get("status") == "success":
+                content = result.get("content", "")
+            else:
+                create_note(title)
+                content = ""
+            run_on_ui(controller, open_note_editor, title, content, controller.view.master)
         elif command == "delete_note":
             if not title:
                 return

--- a/plugins/note_taker/intent_map.json
+++ b/plugins/note_taker/intent_map.json
@@ -7,6 +7,10 @@
   "search": "search_notes",
   "search_notes": "search_notes",
   "search_notes_by_keyword": "search_notes",
-  "clarify_action": "read_note",
+  "clarify_action": "edit_note",
+  "confirm_action": "edit_note",
+  "edit": "edit_note",
+  "open": "edit_note",
+  "modify": "edit_note",
   "read_note": "read_note"
 }

--- a/plugins/note_taker/note_taker_prompt.json
+++ b/plugins/note_taker/note_taker_prompt.json
@@ -23,6 +23,18 @@
       }
     },
     {
+      "intent": "edit_note",
+      "description": "当用户提到打开或修改某个笔记时使用。",
+      "example_user_input": "帮我打开'工作计划'笔记",
+      "example_assistant_output": {
+        "plugin": "note_taker",
+        "command": "edit_note",
+        "args": {
+          "title": "工作计划"
+        }
+      }
+    },
+    {
       "user": "删掉那个叫做“购物清单”的笔记",
       "ai": {
         "intent": "delete",

--- a/tests/test_intent_registry.py
+++ b/tests/test_intent_registry.py
@@ -28,7 +28,9 @@ class IntentRegistryTest(unittest.TestCase):
         self.assertIn('create', intent_registry)
         self.assertEqual(intent_registry['create'], ('note_taker', 'create_note'))
         self.assertIn('clarify_action', intent_registry)
-        self.assertEqual(intent_registry['clarify_action'], ('note_taker', 'read_note'))
+        self.assertEqual(intent_registry['clarify_action'], ('note_taker', 'edit_note'))
+        self.assertIn('edit', intent_registry)
+        self.assertEqual(intent_registry['edit'], ('note_taker', 'edit_note'))
         self.assertIn('search_notes_by_keyword', intent_registry)
         self.assertEqual(
             intent_registry['search_notes_by_keyword'],


### PR DESCRIPTION
## Summary
- extend note_taker plugin with new `edit_note` command
- open editor only for `edit_note`; `read_note` now replies with note content
- teach intent mapping and prompt about the new behaviour
- update unit tests for new mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f392fb128832cac69c9bdd62db0a9