### PR TITLE
Add needs clarification intent

### DIFF
--- a/IntentDetector/ai_service/prompts.json
+++ b/IntentDetector/ai_service/prompts.json
@@ -1,6 +1,6 @@
 {
   "command_recognizer": {
-    "system_prompt": "你是一个名为Nana的AI助手。你的主要任务是和用户愉快地聊天。有时用户会下达特定指令，如果指令明确且你拥有对应插件的知识，就以严格的JSON格式返回指令，JSON对象必须包含'plugin', 'command', 'args', 'response'四个键。如果只是普通聊天，或者你不确定用户的意图，请将'plugin'键设为null。",
+    "system_prompt": "你是一个名为Nana的AI助手。你的主要任务是和用户愉快地聊天。有时用户会下达特定指令，如果指令明确且你拥有对应插件的知识，就以严格的JSON格式返回指令，JSON对象必须包含'plugin', 'command', 'args', 'response'四个键。如果只是普通聊天，或者你不确定用户的意图，请将'plugin'键设为null；若无法确定用户真正想要什么，请把'intent'设为'needs_clarification'并在'response'里向用户提出澄清问题。",
     "examples": [
       {
         "user": "你叫什么名字呀？",
@@ -18,6 +18,26 @@
           "command": null,
           "args": null,
           "response": "是呀是呀，天气好心情也好呢！"
+        }
+      },
+      {
+        "user": "那个...笔记...学习一下",
+        "ai": {
+          "intent": "needs_clarification",
+          "plugin": null,
+          "command": null,
+          "args": null,
+          "response": "对不起，我不太明白您的意思，您是想‘创建笔记’还是‘搜索笔记’呢？"
+        }
+      },
+      {
+        "user": "帮我删了那个",
+        "ai": {
+          "intent": "needs_clarification",
+          "plugin": null,
+          "command": null,
+          "args": null,
+          "response": "好的，但是您想让我删除哪个笔记呢？可以告诉我它的名字吗？"
         }
       }
     ]

--- a/main.py
+++ b/main.py
@@ -80,6 +80,11 @@ class AppController:
             response_msg = ("Nana酱", ai_response, "nana_sender")
             self.view.ui_queue.put(("APPEND_MESSAGE", response_msg))
             self.conversation_history.append({"role": "assistant", "content": ai_response})
+        if command.get("intent") == "needs_clarification":
+            # 只显示反问语句，不调用任何插件
+            self.view.ui_queue.put(("SET_STATE", "enabled"))
+            return
+
         self.executor.execute_command(command, self)
         self.view.ui_queue.put(("SET_STATE", "enabled"))
 

--- a/tests/test_needs_clarification.py
+++ b/tests/test_needs_clarification.py
@@ -1,0 +1,19 @@
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from global_config import settings
+
+class ClarificationPromptTest(unittest.TestCase):
+    def test_prompt_contains_clarification_intent(self):
+        with open(settings.PROMPTS_FILE, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        examples = data['command_recognizer']['examples']
+        intents = [ex.get('ai', {}).get('intent') for ex in examples]
+        self.assertIn('needs_clarification', intents)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `needs_clarification` intent examples and system prompt info
- handle clarification intent in the main controller
- ensure prompts contain new intent via tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f788245e4832c837558b728367b15