### PR TITLE
Add rename note command

### DIFF
--- a/plugins/note_taker/__init__.py
+++ b/plugins/note_taker/__init__.py
@@ -7,6 +7,7 @@ from .notetaker_handle import (
     delete_note,
     list_notes,
     search_notes,
+    rename_note,
 )
 from .notetaker_ui import open_note_editor, open_notes_window, confirm_delete
 import queue
@@ -35,6 +36,7 @@ class NoteTakerPlugin(BasePlugin):
             "delete_note",
             "list_notes",
             "search_notes",
+            "rename_note",
         ]
 
     def on_load(self):
@@ -125,6 +127,15 @@ class NoteTakerPlugin(BasePlugin):
                         ),
                     )
                 )
+        elif command == "rename_note":
+            new_title = args.get("new_title") if args else None
+            if not title or not new_title:
+                return
+            result = rename_note(title, new_title)
+            if result.get("status") == "success":
+                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", result.get("message", ""), "nana_sender")))
+            else:
+                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana酱", result.get("message", ""), "error_sender")))
         else:
             logger.warning(f"未识别的命令: {command}")
 

--- a/plugins/note_taker/intent_map.json
+++ b/plugins/note_taker/intent_map.json
@@ -12,5 +12,6 @@
   "edit": "edit_note",
   "open": "edit_note",
   "modify": "edit_note",
-  "read_note": "read_note"
+  "read_note": "read_note",
+  "rename_note": "rename_note"
 }

--- a/plugins/note_taker/note_taker_prompt.json
+++ b/plugins/note_taker/note_taker_prompt.json
@@ -126,6 +126,20 @@
         "response": "明白！正在为你打开笔记“教程1”。",
         "success_response": null
       }
+    },
+    {
+      "intent": "rename_note",
+      "description": "当用户想要修改一个已存在笔记的名称时使用。",
+      "example_user_input": "把笔记'购物清单'的名字改成'周末采购计划'",
+      "example_assistant_output": {
+        "plugin": "note_taker",
+        "command": "rename_note",
+        "args": {
+          "title": "购物清单",
+          "new_title": "周末采购计划"
+        },
+        "response": "好的，我这就去修改笔记名称！"
+      }
     }
   ]
 }

--- a/plugins/note_taker/notetaker_handle.py
+++ b/plugins/note_taker/notetaker_handle.py
@@ -79,3 +79,24 @@ def search_notes(keyword: str) -> list[str]:
             results.append(note_name)
     return sorted(results)
 
+
+def rename_note(old_title: str, new_title: str) -> dict:
+    """重命名现有笔记"""
+    ensure_notes_folder_exists()
+    old_file_path = get_note_path(old_title)
+    new_file_path = get_note_path(new_title)
+
+    if not os.path.exists(old_file_path):
+        return {"status": "error", "message": f"错误：找不到名为 '{old_title}' 的笔记。"}
+
+    if os.path.exists(new_file_path):
+        return {"status": "error", "message": f"错误：名为 '{new_title}' 的笔记已经存在了，换个新名字吧！"}
+
+    try:
+        os.rename(old_file_path, new_file_path)
+        print(f"成功将笔记 '{old_title}' 重命名为 '{new_title}'")
+        return {"status": "success", "message": f"成功将笔记 '{old_title}' 重命名为 '{new_title}'！"}
+    except Exception as e:
+        print(f"重命名文件时发生错误: {e}")
+        return {"status": "error", "message": f"修改笔记名称时发生意外：{e}"}
+


### PR DESCRIPTION
## Summary
- support renaming notes in the note_taker plugin
- describe the new intent in the plugin prompt
- map the `rename_note` intent to its command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f7b5166b8832cbc551ba84e51d4c6