### PR TITLE
Remove read_note feature

### DIFF
--- a/IntentDetector/ai_service/prompts.json
+++ b/IntentDetector/ai_service/prompts.json
@@ -1,6 +1,6 @@
 {
   "command_recognizer": {
-    "system_prompt": "你是一个名为Nana的AI助手。你的主要任务是和用户愉快地聊天。有时用户会下达特定指令，如果指令明确且你拥有对应插件的知识，就以严格的JSON格式返回指令，JSON对象必须包含'plugin', 'command', 'args', 'response'四个键。如果只是普通聊天，或者你不确定用户的意图，请将'plugin'键设为null；若无法确定用户真正想要什么，请把'intent'设为'needs_clarification'并在'response'里向用户提出澄清问题。首先判断用户属于\"动手\"(执行命令)还是\"动脑\"(回答问题)。若是动脑，请优先依次考虑: 1) answer_from_note, 2) note_taker.search_notes, 3) note_taker.read_note。",
+    "system_prompt": "你是一个名为Nana的AI助手。你的主要任务是和用户愉快地聊天。有时用户会下达特定指令，如果指令明确且你拥有对应插件的知识，就以严格的JSON格式返回指令，JSON对象必须包含'plugin', 'command', 'args', 'response'四个键。如果只是普通聊天，或者你不确定用户的意图，请将'plugin'键设为null；若无法确定用户真正想要什么，请把'intent'设为'needs_clarification'并在'response'里向用户提出澄清问题。首先判断用户属于\"动手\"(执行命令)还是\"动脑\"(回答问题)。若是动脑，请优先依次考虑: 1) answer_from_note, 2) note_taker.search_notes。",
     "examples": [
       {
         "user": "你叫什么名字呀？",

--- a/_prompt.json
+++ b/_prompt.json
@@ -14,13 +14,6 @@
       "args": {
         "title": "String // 搜索关键词"
       }
-    },
-    {
-      "command": "note_taker.read_note",
-      "description": "最低优先级：仅当用户明确要求‘朗读’或‘显示’一篇笔记的全文，且没有提出任何具体问题时，才使用此命令。",
-      "args": {
-        "title": "String // 要朗读的笔记标题"
-      }
     }
   ]
 }

--- a/plugins/base_plugin.py
+++ b/plugins/base_plugin.py
@@ -27,7 +27,7 @@ class BasePlugin:
     def get_commands(self) -> list[str]:
         """
         【必须实现】返回这个插件能执行的所有命令列表。
-        例如: ['create_note', 'read_note', 'delete_note']
+        例如: ['create_note', 'edit_note', 'delete_note']
         CommandExecutor 会用这个列表来知道“这个插件会做什么”。
         """
         raise NotImplementedError("每个插件都必须实现 get_commands() 方法！")

--- a/plugins/note_taker/intent_map.json
+++ b/plugins/note_taker/intent_map.json
@@ -1,6 +1,5 @@
 {
   "create": "create_note",
-  "read": "read_note",
   "delete": "delete_note",
   "show_notes": "list_notes",
 
@@ -12,6 +11,5 @@
   "edit": "edit_note",
   "open": "edit_note",
   "modify": "edit_note",
-  "read_note": "read_note",
   "rename_note": "rename_note"
 }

--- a/plugins/note_taker/note_taker_prompt.json
+++ b/plugins/note_taker/note_taker_prompt.json
@@ -12,15 +12,6 @@
       }
     },
     {
-      "user": "我想看看我的'购物清单'笔记里写了什么",
-      "ai": {
-        "plugin": "note_taker",
-        "command": "read_note",
-        "args": {"title": "购物清单"},
-        "response": "好的，正在为你读取笔记..."
-      }
-    },
-    {
       "user": "帮我打开'工作计划'笔记",
       "ai": {
         "plugin": "note_taker",

--- a/plugins/note_taker/notetaker_handle.py
+++ b/plugins/note_taker/notetaker_handle.py
@@ -43,21 +43,6 @@ def create_note(note_name: str) -> bool:
 def delete_note(note_name: str) -> None:
     os.remove(get_note_path(note_name))
 
-def read_note(note_name: str) -> dict:
-    """读取指定笔记内容并返回统一的结果结构"""
-    if not note_name or os.path.basename(note_name) != note_name:
-        return {"status": "error", "message": "无效的笔记标题"}
-
-    note_path = get_note_path(note_name)
-    if not os.path.exists(note_path):
-        return {"status": "error", "message": f"笔记 '{note_name}' 不存在"}
-
-    try:
-        with open(note_path, "r", encoding="utf-8") as f:
-            content = f.read()
-        return {"status": "success", "content": content}
-    except Exception as e:
-        return {"status": "error", "message": str(e)}
 
 
 def search_notes(keyword: str) -> list[str]:

--- a/plugins/note_taker/notetaker_ui.py
+++ b/plugins/note_taker/notetaker_ui.py
@@ -1,6 +1,6 @@
 import tkinter as tk
 from tkinter import scrolledtext, messagebox
-from .notetaker_handle import get_note_path, read_note
+from .notetaker_handle import get_note_path, get_note_content
 from Gui.config import gui_config
 
 
@@ -70,11 +70,8 @@ def open_notes_window(notes: list[str], master_window=None):
         selection = listbox.curselection()
         if selection:
             note_name = listbox.get(selection[0])
-            result = read_note(note_name)
-            if result.get("status") == "success":
-                open_note_editor(note_name, result.get("content", ""), master_window)
-            else:
-                messagebox.showerror("打开失败", f"无法打开笔记 '{note_name}': {result.get('message', '')}")
+            content = get_note_content(note_name) or ""
+            open_note_editor(note_name, content, master_window)
 
     listbox.bind("<Double-1>", on_open)
 


### PR DESCRIPTION
## Summary
- purge `read_note` command from note_taker plugin
- update plugin UI to use `get_note_content`
- delete `read_note` function from handler
- drop `read_note` from prompts and intent map
- clean up examples and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687471bdcb60832cbc0c84b93856133f