### PR TITLE
Move note answering logic to plugin

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ from Gui.windows.main_window import MainWindow
 from IntentDetector.main_detector import MainDetector
 from CommandExecutor.cmd_main import CommandExecutor
 from core.plugin_system.plugin_manager import PluginManager
-from plugins.note_taker.notetaker_handle import get_note_content
+
 
 
 # 【注意】: 下面的 AppController 和 if __name__ == "__main__": 部分，
@@ -53,42 +53,6 @@ class AppController:
         # --- 接线完成！现在它们俩已经成功关联啦！---
 
         self.conversation_history = []
-
-    def _handle_answer_from_note(self, command: dict):
-        args = command.get("args", {}) or {}
-        note_title = args.get("title")
-        user_question = args.get("question")
-
-        if not note_title or not user_question:
-            self.view.ui_queue.put(
-                ("APPEND_MESSAGE", ("Nana", "抱歉，我没有理解要查哪个笔记或具体问题是什么。", "nana_sender"))
-            )
-            return
-
-        self.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", f"正在翻阅《{note_title}》笔记...", "nana_sender")))
-        note_content = get_note_content(note_title)
-
-        if note_content:
-            qa_prompt = f"""
-            你是一个智能助手，请严格根据下面提供的“笔记内容”，回答用户的“问题”。
-            要求：
-            1. 你的回答必须完全基于提供的“笔记内容”。
-            2. 如果笔记内容无法回答问题，请明确说明“根据笔记内容，我无法回答这个问题”。
-            3. 不要编造任何笔记中不存在的信息。
-
-            --- 笔记内容 ---
-            标题：{note_title}
-            {note_content}
-            --- 笔记内容结束 ---
-
-            现在，请回答这个问题："{user_question}"
-            """
-
-            self.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", "正在思考答案...", "nana_sender")))
-            final_answer = self.detector.ai_service.get_completion(qa_prompt)
-            self.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", final_answer, "nana_sender")))
-        else:
-            self.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", f"抱歉主人，我找不到名为《{note_title}》的笔记哦。", "nana_sender")))
 
     def set_view(self, view: MainWindow):
         """让控制器能够访问到GUI实例，以便操作UI队列。"""
@@ -123,7 +87,9 @@ class AppController:
             return
 
         if command.get("command") == "answer_from_note":
-            self._handle_answer_from_note(command)
+            note_plugin = self.plugin_manager.plugins.get("note_taker")
+            if note_plugin and hasattr(note_plugin, "answer_from_note"):
+                note_plugin.answer_from_note(command.get("args", {}) or {}, self)
         else:
             self.executor.execute_command(command, self)
         self.view.ui_queue.put(("SET_STATE", "enabled"))

--- a/plugins/note_taker/__init__.py
+++ b/plugins/note_taker/__init__.py
@@ -114,8 +114,71 @@ class NoteTakerPlugin(BasePlugin):
                 controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", result.get("message", ""), "nana_sender")))
             else:
                 controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana酱", result.get("message", ""), "error_sender")))
+        elif command == "answer_from_note":
+            self.answer_from_note(args or {}, controller)
         else:
             logger.warning(f"未识别的命令: {command}")
+
+    def answer_from_note(self, args: dict, controller):
+        """根据笔记内容回答问题"""
+        note_title = args.get("title")
+        user_question = args.get("question")
+
+        if not note_title or not user_question:
+            controller.view.ui_queue.put(
+                (
+                    "APPEND_MESSAGE",
+                    (
+                        "Nana",
+                        "抱歉，我没有理解要查哪个笔记或具体问题是什么。",
+                        "nana_sender",
+                    ),
+                )
+            )
+            return
+
+        controller.view.ui_queue.put(
+            (
+                "APPEND_MESSAGE",
+                ("Nana", f"正在翻阅《{note_title}》笔记...", "nana_sender"),
+            )
+        )
+        note_content = get_note_content(note_title)
+
+        if note_content:
+            qa_prompt = f"""
+            你是一个智能助手，请严格根据下面提供的“笔记内容”，回答用户的“问题”。
+            要求：
+            1. 你的回答必须完全基于提供的“笔记内容”。
+            2. 如果笔记内容无法回答问题，请明确说明“根据笔记内容，我无法回答这个问题”。
+            3. 不要编造任何笔记中不存在的信息。
+
+            --- 笔记内容 ---
+            标题：{note_title}
+            {note_content}
+            --- 笔记内容结束 ---
+
+            现在，请回答这个问题："{user_question}"
+            """
+
+            controller.view.ui_queue.put(
+                ("APPEND_MESSAGE", ("Nana", "正在思考答案...", "nana_sender"))
+            )
+            final_answer = controller.detector.ai_service.get_completion(qa_prompt)
+            controller.view.ui_queue.put(
+                ("APPEND_MESSAGE", ("Nana", final_answer, "nana_sender"))
+            )
+        else:
+            controller.view.ui_queue.put(
+                (
+                    "APPEND_MESSAGE",
+                    (
+                        "Nana",
+                        f"抱歉主人，我找不到名为《{note_title}》的笔记哦。",
+                        "nana_sender",
+                    ),
+                )
+            )
 
 
 def get_plugin():


### PR DESCRIPTION
## Summary
- shift `_handle_answer_from_note` logic from main controller into the `note_taker` plugin
- call the plugin method when command `answer_from_note` is detected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68747c7a9f98832c8a4de0cc32a63819