### PR TITLE
整理GUI和笔记插件配置

### DIFF
--- a/Gui/config/gui_config.py
+++ b/Gui/config/gui_config.py
@@ -8,7 +8,6 @@ ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 # 基于根目录构建其他路径 (Build other paths based on the root directory)
 IMAGES_DIR = os.path.join(ROOT_DIR, "images")
 CONFIG_DIR = os.path.join(ROOT_DIR, "config")
-NOTES_DIR = os.path.join(ROOT_DIR, "plugins", "note_taker", "MyNotes")
 
 # --- 文件名管理 (File Name Management) ---
 PERSONA_FILE = os.path.join(ROOT_DIR, "nana_persona.txt")
@@ -23,6 +22,7 @@ APP_TITLE = "Nana的AI记事本 ✨"
 NOTES_WINDOW_TITLE = "我的笔记"
 NOTE_EDITOR_TITLE_PREFIX = "编辑笔记："
 SAVE_BUTTON_TEXT = "保存笔记"
+MAIN_WINDOW_SIZE = "1100x800"
 # 发送者名称 (Sender Names)
 SENDER_USER = "你"
 SENDER_AI = "Nana"

--- a/Gui/windows/main_window.py
+++ b/Gui/windows/main_window.py
@@ -29,7 +29,7 @@ class MainWindow:
             self.img_send_normal = None
         # --- 1. 基础窗口设置 ---
         self.master.title(self.gui_config.APP_TITLE)
-        self.master.geometry("1100x800")
+        self.master.geometry(self.gui_config.MAIN_WINDOW_SIZE)
         self.master.config(bg=self.gui_config.BG_MAIN)
         self.master.protocol("WM_DELETE_WINDOW", self.on_closing)
 

--- a/plugins/note_taker/note_config.py
+++ b/plugins/note_taker/note_config.py
@@ -1,0 +1,12 @@
+import os
+from global_config import settings
+
+# 笔记存储文件夹名
+NOTES_FOLDER = "MyNotes"
+
+# 完整笔记目录
+NOTES_DIR = os.path.join(settings.PLUGINS_DIR, 'note_taker', NOTES_FOLDER)
+
+# 笔记编辑器默认尺寸
+EDITOR_WIDTH = 80
+EDITOR_HEIGHT = 25

--- a/plugins/note_taker/notetaker_handle.py
+++ b/plugins/note_taker/notetaker_handle.py
@@ -1,10 +1,6 @@
 import os
-from Gui.config import gui_config
 from datetime import datetime
-NOTES_FOLDER = "MyNotes"
-
-# Ensure notes directory exists
-NOTES_DIR = gui_config.NOTES_DIR
+from .note_config import NOTES_DIR, NOTES_FOLDER
 
 def ensure_notes_folder_exists():
     """确保笔记文件夹存在。如不存在则尝试创建；

--- a/plugins/note_taker/notetaker_ui.py
+++ b/plugins/note_taker/notetaker_ui.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import scrolledtext, messagebox
 from .notetaker_handle import get_note_path, get_note_content
 from Gui.config import gui_config
+from .note_config import EDITOR_WIDTH, EDITOR_HEIGHT
 
 
 def open_note_editor(note_name: str, content: str = "", master_window=None):
@@ -12,8 +13,8 @@ def open_note_editor(note_name: str, content: str = "", master_window=None):
     text_area = scrolledtext.ScrolledText(
         editor_window,
         wrap=tk.WORD,
-        width=80,
-        height=25,
+        width=EDITOR_WIDTH,
+        height=EDITOR_HEIGHT,
         font=(gui_config.GENERAL_FONT_FAMILY, gui_config.GENERAL_FONT_SIZE),
         bg=gui_config.BG_INPUT,
         fg=gui_config.FG_TEXT,


### PR DESCRIPTION
## Summary
- 在 `gui_config.py` 中新增 `MAIN_WINDOW_SIZE` 并移除笔记目录常量
- 新建 `note_config.py` 管理笔记插件参数
- 更新 `notetaker_handle.py` 与 `notetaker_ui.py` 使用新的配置
- 主窗口尺寸从代码中挪至配置文件

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875cbfffcf4832cb0c44b9952762bfe