### PR TITLE
Move note_taker messages into config

### DIFF
--- a/plugins/note_taker/note_config.py
+++ b/plugins/note_taker/note_config.py
@@ -10,3 +10,29 @@ NOTES_DIR = os.path.join(settings.PLUGINS_DIR, 'note_taker', NOTES_FOLDER)
 # 笔记编辑器默认尺寸
 EDITOR_WIDTH = 40
 EDITOR_HEIGHT = 60
+
+# --- 消息模板 ---
+# 重命名笔记相关
+RENAME_NOTE_NOT_FOUND = "错误：找不到名为 '{old_title}' 的笔记。"
+RENAME_NOTE_EXISTS = "错误：名为 '{new_title}' 的笔记已经存在了，换个新名字吧！"
+RENAME_NOTE_SUCCESS = "成功将笔记 '{old_title}' 重命名为 '{new_title}'！"
+RENAME_NOTE_ERROR = "修改笔记名称时发生意外：{e}"
+
+# 在笔记中追加内容时的时间戳前缀
+NOTE_APPEND_PREFIX = "--- (Nana帮你记在 {timestamp}) ---"
+
+# 插件交互消息
+CREATE_SUCCESS = "新建笔记 '{title}' 成功。"
+NOTE_EXISTS = "笔记 '{title}' 已存在。"
+DELETE_SUCCESS = "已删除笔记 '{title}'。"
+NOTE_NOT_FOUND = "笔记 '{title}' 不存在。"
+NO_NOTES_FOUND = "没有找到任何笔记。"
+SEARCH_RESULTS = "我找到了和 '{keyword}' 相关的笔记有这些哦：\n{note_list}\n需要我帮你打开哪一个吗？"
+SEARCH_NONE = "没有找到与 '{keyword}' 相关的笔记。"
+CANCEL_DELETE = "已取消删除。"
+PARAM_MISSING = "哎呀，我好像忘记要记什么或者记在哪里了..."
+APPEND_SUCCESS = "我已经帮你把内容添加到《{title}》里啦！"
+APPEND_ERROR = "糟糕...在给《{title}》做笔记的时候出错了。"
+READING_NOTE = "正在翻阅《{note_title}》笔记..."
+NOTE_QA_NOT_FOUND = "抱歉主人，我找不到名为《{note_title}》的笔记哦。"
+UNKNOWN_QA = "抱歉，我没有理解要查哪个笔记或具体问题是什么。"

--- a/plugins/note_taker/notetaker_handle.py
+++ b/plugins/note_taker/notetaker_handle.py
@@ -1,6 +1,14 @@
 import os
 from datetime import datetime
-from .note_config import NOTES_DIR, NOTES_FOLDER
+from .note_config import (
+    NOTES_DIR,
+    NOTES_FOLDER,
+    RENAME_NOTE_NOT_FOUND,
+    RENAME_NOTE_EXISTS,
+    RENAME_NOTE_SUCCESS,
+    RENAME_NOTE_ERROR,
+    NOTE_APPEND_PREFIX,
+)
 
 def ensure_notes_folder_exists():
     """确保笔记文件夹存在。如不存在则尝试创建；
@@ -68,18 +76,18 @@ def rename_note(old_title: str, new_title: str) -> dict:
     new_file_path = get_note_path(new_title)
 
     if not os.path.exists(old_file_path):
-        return {"status": "error", "message": f"错误：找不到名为 '{old_title}' 的笔记。"}
+        return {"status": "error", "message": RENAME_NOTE_NOT_FOUND.format(old_title=old_title)}
 
     if os.path.exists(new_file_path):
-        return {"status": "error", "message": f"错误：名为 '{new_title}' 的笔记已经存在了，换个新名字吧！"}
+        return {"status": "error", "message": RENAME_NOTE_EXISTS.format(new_title=new_title)}
 
     try:
         os.rename(old_file_path, new_file_path)
         print(f"成功将笔记 '{old_title}' 重命名为 '{new_title}'")
-        return {"status": "success", "message": f"成功将笔记 '{old_title}' 重命名为 '{new_title}'！"}
+        return {"status": "success", "message": RENAME_NOTE_SUCCESS.format(old_title=old_title, new_title=new_title)}
     except Exception as e:
         print(f"重命名文件时发生错误: {e}")
-        return {"status": "error", "message": f"修改笔记名称时发生意外：{e}"}
+        return {"status": "error", "message": RENAME_NOTE_ERROR.format(e=e)}
 
 
 def get_note_content(title: str) -> str | None:
@@ -108,7 +116,7 @@ def append_to_note(title: str, content: str) -> bool:
 
     # 格式化要追加的内容
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
-    formatted_content = f"\n\n--- (Nana帮你记在 {timestamp}) ---\n{content}\n"
+    formatted_content = f"\n\n{NOTE_APPEND_PREFIX.format(timestamp=timestamp)}\n{content}\n"
 
     try:
         # 使用 'a' 模式来追加内容，文件不存在会自动创建


### PR DESCRIPTION
## Summary
- centralize note_taker plugin messages in `note_config.py`
- reference new message constants in plugin logic
- use the constants in note handling functions

## Testing
- `python -m py_compile plugins/note_taker/*.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6875d16a85a4832c8b43c6548fc3c57e