### PR TITLE
更新 README 为中文使用说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,49 @@
 # Nana 2
 
-Nana 2 is a small desktop assistant built with `tkinter`.  
-It uses OpenAI's API via DashScope for natural language command recognition and provides a plugin system for extending its skills.
+Nana 2 是一个使用 `tkinter` 构建的桌面助手，依托 DashScope 提供的 OpenAI 兼容接口进行自然语言识别，并通过插件系统扩展能力。
 
-## Setup
+## 环境准备
 
-1. **Create a virtual environment** (optional but recommended):
+1. **创建虚拟环境**（可选）：
    ```bash
    python -m venv venv
-   source venv/bin/activate  # On Windows use `venv\Scripts\activate`
+   source venv/bin/activate  # Windows 使用 venv\Scripts\activate
    ```
-2. **Install dependencies**:
+2. **安装依赖**：
    ```bash
    pip install -r requirements.txt
    ```
-3. **Configure API key**:
-   Create a `.env` file in the project root containing:
+3. **配置 API 密钥**：在项目根目录创建 `.env` 文件，内容如下：
    ```env
    DASHSCOPE_API_KEY=your_openai_key
    ```
-4. **Run the application**:
+4. **启动程序**：
    ```bash
-   python nana_2/main.py
+   python main.py
    ```
 
-The GUI will launch and connect to the AI service.  Plugins are loaded from the `nana_2/plugins` directory.
+程序启动后会连接 AI 服务，并自动加载 `plugins` 目录下的插件。
 
-## Plugin Interface
+## 插件接口
 
-To extend Nana 2, create a folder under `nana_2/plugins` and implement a
-Python module exposing a `get_plugin()` function. This function must return an
-instance of a class inheriting from `BasePlugin`.
+如需扩展功能，可在 `plugins` 目录新建文件夹并实现模块，提供 `get_plugin()`
+函数并返回继承 `BasePlugin` 的实例。
 
-Each plugin class should implement the following methods:
+插件需实现以下方法：
 
-* `get_name()` - return the unique identifier for the plugin
-* `get_commands()` - list of commands this plugin can execute
-* `execute(command, args, controller)` - handle the actual task
+* `get_name()` - 插件的唯一标识
+* `get_commands()` - 插件支持的命令列表
+* `execute(command, args, controller)` - 执行具体任务
 
-`CommandExecutor` dynamically imports plugins via `get_plugin()` and registers
-their commands automatically.
+`CommandExecutor` 会根据 `get_plugin()` 动态导入插件并注册命令。
+
+## 运行测试
+
+项目内含若干单元测试，可使用 `pytest` 执行：
+
+```bash
+pytest
+```
+
+确保测试依赖已正确安装。
+


### PR DESCRIPTION
## Summary
- 完整翻译 README，改为中文说明
- 更正启动命令并新增测试运行说明

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6876082c3e9c832ca192b9d3685adea1