### PR TITLE
refactor sender names as global constants

### DIFF
--- a/global_config/settings.py
+++ b/global_config/settings.py
@@ -44,3 +44,8 @@ IMG_SEND_PRESS = os.path.join(IMAGES_DIR, "button_press.png")
 # 其他全局配置
 APP_VERSION = "2.0.0"
 AUTHOR = "你的名字"
+
+# 聊天窗口中显示的名称
+USER_NAME = "你"
+AI_NAME = "Nana"
+AI_NAME_FRIENDLY = "Nana酱"

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ from Gui.windows.main_window import MainWindow
 from IntentDetector.main_detector import MainDetector
 from CommandExecutor.cmd_main import CommandExecutor
 from core.plugin_system.plugin_manager import PluginManager
+from global_config.settings import USER_NAME, AI_NAME, AI_NAME_FRIENDLY
 
 
 
@@ -60,12 +61,12 @@ class AppController:
 
     def start_app(self):
         """应用启动时，由 main 函数调用。"""
-        welcome_msg = ("Nana", "ready to start!", "nana_sender")
+        welcome_msg = (AI_NAME, "ready to start!", "nana_sender")
         self.view.ui_queue.put(("APPEND_MESSAGE", welcome_msg))
 
     def process_user_input(self, user_text: str):
         """这是从GUI的EventHandler接收用户输入的唯一入口。"""
-        user_msg = ("你", user_text, "user_sender")
+        user_msg = (USER_NAME, user_text, "user_sender")
         self.view.ui_queue.put(("APPEND_MESSAGE", user_msg))
         self.conversation_history.append({"role": "user", "content": user_text})
         thread = threading.Thread(target=self._run_backend_process)
@@ -78,7 +79,7 @@ class AppController:
         command = self.detector.detect_and_parse(self.conversation_history)
         ai_response = command.get("response")
         if ai_response:
-            response_msg = ("Nana酱", ai_response, "nana_sender")
+            response_msg = (AI_NAME_FRIENDLY, ai_response, "nana_sender")
             self.view.ui_queue.put(("APPEND_MESSAGE", response_msg))
             self.conversation_history.append({"role": "assistant", "content": ai_response})
         if command.get("intent") == "needs_clarification":

--- a/plugins/note_taker/__init__.py
+++ b/plugins/note_taker/__init__.py
@@ -1,5 +1,6 @@
 from plugins.base_plugin import BasePlugin
 from core.log.logger_config import logger
+from global_config.settings import AI_NAME, AI_NAME_FRIENDLY
 from .notetaker_handle import (
     ensure_notes_folder_exists,
     create_note,
@@ -70,7 +71,7 @@ class NoteTakerPlugin(BasePlugin):
                 if created
                 else NOTE_EXISTS.format(title=title)
             )
-            controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", msg, "nana_sender")))
+            controller.view.ui_queue.put(("APPEND_MESSAGE", (AI_NAME, msg, "nana_sender")))
             if created:
                 content = ""
             else:
@@ -89,22 +90,22 @@ class NoteTakerPlugin(BasePlugin):
                 return
             confirmed = run_on_ui(controller, confirm_delete, title, controller.view.master)
             if not confirmed:
-                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", CANCEL_DELETE, "nana_sender")))
+                controller.view.ui_queue.put(("APPEND_MESSAGE", (AI_NAME, CANCEL_DELETE, "nana_sender")))
                 return
             try:
                 delete_note(title)
                 msg = DELETE_SUCCESS.format(title=title)
-                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", msg, "nana_sender")))
+                controller.view.ui_queue.put(("APPEND_MESSAGE", (AI_NAME, msg, "nana_sender")))
             except FileNotFoundError:
                 err = NOTE_NOT_FOUND.format(title=title)
-                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana酱", err, "error_sender")))
+                controller.view.ui_queue.put(("APPEND_MESSAGE", (AI_NAME_FRIENDLY, err, "error_sender")))
         elif command == "list_notes":
             notes = list_notes()
             if notes:
                 run_on_ui(controller, open_notes_window, notes, controller.view.master)
 
             else:
-                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", NO_NOTES_FOUND, "nana_sender")))
+                controller.view.ui_queue.put(("APPEND_MESSAGE", (AI_NAME, NO_NOTES_FOUND, "nana_sender")))
         elif command == "search_notes":
             keyword = args.get("keyword") if args else None
             if not keyword:
@@ -113,19 +114,19 @@ class NoteTakerPlugin(BasePlugin):
             if notes:
                 note_list = "\n".join(f"- {n}" for n in notes)
                 msg = SEARCH_RESULTS.format(keyword=keyword, note_list=note_list)
-                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", msg, "nana_sender")))
+                controller.view.ui_queue.put(("APPEND_MESSAGE", (AI_NAME, msg, "nana_sender")))
                 run_on_ui(controller, open_notes_window, notes, controller.view.master)
             else:
-                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", SEARCH_NONE.format(keyword=keyword), "nana_sender")))
+                controller.view.ui_queue.put(("APPEND_MESSAGE", (AI_NAME, SEARCH_NONE.format(keyword=keyword), "nana_sender")))
         elif command == "rename_note":
             new_title = args.get("new_title") if args else None
             if not title or not new_title:
                 return
             result = rename_note(title, new_title)
             if result.get("status") == "success":
-                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", result.get("message", ""), "nana_sender")))
+                controller.view.ui_queue.put(("APPEND_MESSAGE", (AI_NAME, result.get("message", ""), "nana_sender")))
             else:
-                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana酱", result.get("message", ""), "error_sender")))
+                controller.view.ui_queue.put(("APPEND_MESSAGE", (AI_NAME_FRIENDLY, result.get("message", ""), "error_sender")))
         elif command == "answer_from_note":
             self.answer_from_note(args or {}, controller)
         elif command == "append_to_note":
@@ -134,7 +135,7 @@ class NoteTakerPlugin(BasePlugin):
 
             if not title or not content_to_add:
                 # AI一般不会犯这种错，但以防万一
-                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana酱", PARAM_MISSING, "error_sender")))
+                controller.view.ui_queue.put(("APPEND_MESSAGE", (AI_NAME_FRIENDLY, PARAM_MISSING, "error_sender")))
                 return
 
             success = append_to_note(title, content_to_add)
@@ -142,13 +143,13 @@ class NoteTakerPlugin(BasePlugin):
             if success:
                 # 成功后的反馈
                 msg = APPEND_SUCCESS.format(title=title)
-                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", msg, "nana_sender")))
+                controller.view.ui_queue.put(("APPEND_MESSAGE", (AI_NAME, msg, "nana_sender")))
                 # 打开笔记让用户检查
                 note_content = get_note_content(title) or ""
                 run_on_ui(controller, open_note_editor, title, note_content, controller.view.master)
             else:
                 # 失败后的反馈
-                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana酱", APPEND_ERROR.format(title=title), "error_sender")))
+                controller.view.ui_queue.put(("APPEND_MESSAGE", (AI_NAME_FRIENDLY, APPEND_ERROR.format(title=title), "error_sender")))
         else:
             logger.warning(f"未识别的命令: {command}")
 
@@ -158,10 +159,10 @@ class NoteTakerPlugin(BasePlugin):
         user_question = args.get("question")
 
         if not note_title or not user_question:
-            controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", UNKNOWN_QA, "nana_sender")))
+            controller.view.ui_queue.put(("APPEND_MESSAGE", (AI_NAME, UNKNOWN_QA, "nana_sender")))
             return
 
-        controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", READING_NOTE.format(note_title=note_title), "nana_sender")))
+        controller.view.ui_queue.put(("APPEND_MESSAGE", (AI_NAME, READING_NOTE.format(note_title=note_title), "nana_sender")))
         note_content = get_note_content(note_title)
 
         if note_content:
@@ -181,14 +182,14 @@ class NoteTakerPlugin(BasePlugin):
             """
 
             controller.view.ui_queue.put(
-                ("APPEND_MESSAGE", ("Nana", "正在思考答案...", "nana_sender"))
+                ("APPEND_MESSAGE", (AI_NAME, "正在思考答案...", "nana_sender"))
             )
             final_answer = controller.detector.ai_service.get_completion(qa_prompt)
             controller.view.ui_queue.put(
-                ("APPEND_MESSAGE", ("Nana", final_answer, "nana_sender"))
+                ("APPEND_MESSAGE", (AI_NAME, final_answer, "nana_sender"))
             )
         else:
-            controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", NOTE_QA_NOT_FOUND.format(note_title=note_title), "nana_sender")))
+            controller.view.ui_queue.put(("APPEND_MESSAGE", (AI_NAME, NOTE_QA_NOT_FOUND.format(note_title=note_title), "nana_sender")))
 
 
 def get_plugin():


### PR DESCRIPTION
## Summary
- centralize display names for chat senders in global settings
- use the constants in `main.py`
- apply the same constants to the note_taker plugin

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6878a8e56210832c98de714da6536352